### PR TITLE
Fix engagement update does not use params

### DIFF
--- a/lib/hubspot/engagement.rb
+++ b/lib/hubspot/engagement.rb
@@ -90,9 +90,9 @@ module Hubspot
     # @return [Hubspot::Engagement] self
     def update!(params)
       data = {
-        engagement: engagement,
-        associations: associations,
-        metadata: metadata
+        engagement: params[:engagement]     || engagement,
+        associations: params[:associations] || associations,
+        metadata: params[:metadata]         || metadata,
       }
 
       Hubspot::Connection.put_json(ENGAGEMENT_PATH, params: { engagement_id: id }, body: data)

--- a/lib/hubspot/engagement.rb
+++ b/lib/hubspot/engagement.rb
@@ -156,8 +156,7 @@ module Hubspot
           },
           associations: {
             contactIds: [contact_vid],
-            dealIds: [deal_id],
-            ownerIds: [owner_id]
+            dealIds: [deal_id]
           },
           metadata: {
             body: body,
@@ -190,8 +189,7 @@ module Hubspot
             type: 'TASK'
           },
           associations: {
-            contactIds: [contact_id],
-            ownerIds: [owner_id]
+            contactIds: [contact_id]
           },
           metadata: {
             body: task_body,

--- a/lib/hubspot/engagement.rb
+++ b/lib/hubspot/engagement.rb
@@ -124,7 +124,7 @@ module Hubspot
         }
 
         # if the owner id has been provided, append it to the engagement
-        data[:engagement][:owner_id] = owner_id if owner_id
+        data[:engagement][:ownerId] = owner_id if owner_id
 
         super(data)
       end
@@ -167,7 +167,7 @@ module Hubspot
         }
 
         data[:engagement][:timestamp] = (time.to_i) * 1000 if time
-        data[:engagement][:owner_id] = owner_id if owner_id
+        data[:engagement][:ownerId] = owner_id if owner_id
 
         super(data)
       end
@@ -202,7 +202,7 @@ module Hubspot
         }
 
         # if the owner id has been provided, append it to the engagement
-        data[:engagement][:owner_id] = owner_id if owner_id
+        data[:engagement][:ownerId] = owner_id if owner_id
 
         super(data)
       end

--- a/lib/hubspot/engagement.rb
+++ b/lib/hubspot/engagement.rb
@@ -173,4 +173,39 @@ module Hubspot
       end
     end
   end
+
+  class EngagementTask < Engagement
+    def body
+      metadata['body']
+    end
+
+    def contact_ids
+      associations['contactIds']
+    end
+
+    class << self
+      def create!(contact_id, task_title, task_body, owner_id = nil, status="NOT_STARTED", object_type="CONTACT")
+        data = {
+          engagement: {
+            type: 'TASK'
+          },
+          associations: {
+            contactIds: [contact_id]
+          },
+          metadata: {
+            body: task_body,
+            subject: task_title,
+            status: status,
+            forObjectType: object_type
+          }
+        }
+
+        # if the owner id has been provided, append it to the engagement
+        data[:engagement][:owner_id] = owner_id if owner_id
+
+        super(data)
+      end
+    end
+
+  end
 end

--- a/lib/hubspot/engagement.rb
+++ b/lib/hubspot/engagement.rb
@@ -190,7 +190,8 @@ module Hubspot
             type: 'TASK'
           },
           associations: {
-            contactIds: [contact_id]
+            contactIds: [contact_id],
+            ownerIds: [owner_id]
           },
           metadata: {
             body: task_body,


### PR DESCRIPTION
The fix is already on the main repo:
https://github.com/adimichele/hubspot-ruby/blob/8eb0a64dd0c14c79e631e81bfdc169583e775a46/lib/hubspot/engagement.rb#L110